### PR TITLE
Added package for missing fonts, otherwise updated pandoc 2 with pand…

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update -y \
   && apt-get install -y -o Acquire::Retries=10 --no-install-recommends \
     texlive-latex-base \
     texlive-xetex \
+    texlive-fonts-recommended \
     latex-xcolor \
     texlive-latex-extra \
     fontconfig \


### PR DESCRIPTION
If you are missing this package and try and run this version of the pandoc command:
https://github.com/strongdm/comply/blob/master/internal/render/pandoc.go#L93 it will throw the following error:
`mktextfm ecrm1000`

I know that the comply command can run the correct docker image that is hosted in dockerhub and is using pandoc 1.19.2.1.  In this case I want it part of my build system so I can just run comply from within the same container as what is being built here and set ` pandoc: "pandoc"` in my comply.yml file so it uses the local version instead of trying to do docker in docker.
