### PR TITLE
Fixed date on generated PDFs

### DIFF
--- a/internal/model/fs.go
+++ b/internal/model/fs.go
@@ -108,7 +108,7 @@ func ReadNarratives() ([]*Document, error) {
 		}
 		n.Body = mdmd.body
 		n.FullPath = f.FullPath
-		n.ModifiedAt = f.Info.ModTime()
+		n.ModifiedAt = f.ModTime()
 		n.OutputFilename = fmt.Sprintf("%s-%s.pdf", config.Config().FilePrefix, n.Acronym)
 		narratives = append(narratives, n)
 	}
@@ -133,7 +133,7 @@ func ReadProcedures() ([]*Procedure, error) {
 		}
 		p.Body = mdmd.body
 		p.FullPath = f.FullPath
-		p.ModifiedAt = f.Info.ModTime()
+		p.ModifiedAt = f.ModTime()
 		procedures = append(procedures, p)
 	}
 
@@ -158,7 +158,7 @@ func ReadPolicies() ([]*Document, error) {
 		}
 		p.Body = mdmd.body
 		p.FullPath = f.FullPath
-		p.ModifiedAt = f.Info.ModTime()
+		p.ModifiedAt = f.ModTime()
 		p.OutputFilename = fmt.Sprintf("%s-%s.pdf", config.Config().FilePrefix, p.Acronym)
 		policies = append(policies, p)
 	}

--- a/internal/plugin/github/github.go
+++ b/internal/plugin/github/github.go
@@ -69,10 +69,10 @@ func (g *githubPlugin) Configured() bool {
 
 func (g *githubPlugin) Links() model.TicketLinks {
 	links := model.TicketLinks{}
-	links.AuditAll = fmt.Sprintf("https://github.com/%s/%s/issues?q=is%3Aissue+is%3Aopen+label%3Acomply+label%3Aaudit", g.username, g.reponame)
-	links.AuditOpen = fmt.Sprintf("https://github.com/%s/%s/issues?q=is%3Aissue+is%3Aopen+label%3Acomply+label%3Aaudit", g.username, g.reponame)
-	links.ProcedureAll = fmt.Sprintf("https://github.com/%s/%s/issues?q=is%3Aissue+label%3Acomply+label%3Aprocedure", g.username, g.reponame)
-	links.ProcedureOpen = fmt.Sprintf("https://github.com/%s/%s/issues?q=is%3Aissue+is%3Aopen+label%3Acomply+label%3Aprocedure", g.username, g.reponame)
+	links.AuditAll = fmt.Sprintf("https://github.com/%s/%s/issues?q=is%%3Aissue+is%%3Aopen+label%%3Acomply+label%%3Aaudit", g.username, g.reponame)
+	links.AuditOpen = fmt.Sprintf("https://github.com/%s/%s/issues?q=is%%3Aissue+is%%3Aopen+label%%3Acomply+label%%3Aaudit", g.username, g.reponame)
+	links.ProcedureAll = fmt.Sprintf("https://github.com/%s/%s/issues?q=is%%3Aissue+label%%3Acomply+label%%3Aprocedure", g.username, g.reponame)
+	links.ProcedureOpen = fmt.Sprintf("https://github.com/%s/%s/issues?q=is%%3Aissue+is%%3Aopen+label%%3Acomply+label%%3Aprocedure", g.username, g.reponame)
 	return links
 }
 


### PR DESCRIPTION
All of the generated PDFs were showing 'January 1980' regardless of the modification time of the files. I found that the ModTime() function was being called incorrectly. Easy fix.