### PR TITLE
Minor correction.

### DIFF
--- a/themes/comply-soc2/policies/access.md
+++ b/themes/comply-soc2/policies/access.md
@@ -11,7 +11,7 @@ majorRevisions:
 ---
 # Purpose and Scope
 
-a. The purpose of this policy to define procedures to onboard and offboard users to technical infrastructure in a manner that minimizes the risk of information loss or exposure. 
+a. The purpose of this policy is to define procedures to onboard and offboard users to technical infrastructure in a manner that minimizes the risk of information loss or exposure. 
 
 a. This policy applies to all technical infrastructure within the organization. 
 


### PR DESCRIPTION
The word "is" was missing in the first sentence of Purpose and Scope.