### PR TITLE
ACE template Standards table: Add sorting/filtering and Standard column

### DIFF
--- a/themes/comply-blank/templates/index.ace
+++ b/themes/comply-blank/templates/index.ace
@@ -8,6 +8,7 @@ html lang=en
     script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.0/moment.min.js"
     script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/later/1.2.0/later.min.js"
     script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/prettycron/0.11.0/prettycron.min.js"
+    script type="text/javascript" src="https://unpkg.com/tablefilter@latest/dist/tablefilter/tablefilter.js"
     meta name="viewport" content="width=device-width, initial-scale=1"
     = css
     = javascript
@@ -42,6 +43,7 @@ html lang=en
           }
         }
       }
+
   body
     section.hero.is-primary.is-small
       .hero-body
@@ -193,9 +195,10 @@ html lang=en
           p
             strong Standards
             | specify the controls satisfied by the compliance program.
-      table.table.is-size-4.is-fullwidth
+      table.table.is-size-4.is-fullwidth id="standards-table"
         thead
           tr
+            th Standard
             th Control Key
             th Name
             th Satisfied?
@@ -203,6 +206,7 @@ html lang=en
         tbody
           {{range .Controls }}
           tr
+            td {{.Standard}}
             td {{.ControlKey}}
             td
               strong {{.Name}}
@@ -235,3 +239,26 @@ html lang=en
         }
       }
     }
+
+    var tfConfig = { 
+      base_path: 'https://unpkg.com/tablefilter@latest/dist/tablefilter/',
+      alternate_rows: true,
+      rows_counter: {
+        text: 'Controls: '
+      },
+      btn_reset: {
+        text: 'Clear'
+      },
+      col_types: [
+        'string',
+        'string',
+        'string',
+        'string',
+        'string'
+      ],
+      extensions: [{ name: 'sort' }]
+    }
+
+    var tf = new TableFilter('standards-table',tfConfig);
+    tf.init();
+

--- a/themes/comply-soc2/templates/index.ace
+++ b/themes/comply-soc2/templates/index.ace
@@ -8,6 +8,7 @@ html lang=en
     script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.0/moment.min.js"
     script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/later/1.2.0/later.min.js"
     script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/prettycron/0.11.0/prettycron.min.js"
+    script type="text/javascript" src="https://unpkg.com/tablefilter@latest/dist/tablefilter/tablefilter.js"
     meta name="viewport" content="width=device-width, initial-scale=1"
     = css
     = javascript
@@ -42,6 +43,7 @@ html lang=en
           }
         }
       }
+
   body
     section.hero.is-primary.is-small
       .hero-body
@@ -193,9 +195,10 @@ html lang=en
           p
             strong Standards
             | specify the controls satisfied by the compliance program.
-      table.table.is-size-4.is-fullwidth
+      table.table.is-size-4.is-fullwidth id="standards-table"
         thead
           tr
+            th Standard
             th Control Key
             th Name
             th Satisfied?
@@ -203,6 +206,7 @@ html lang=en
         tbody
           {{range .Controls }}
           tr
+            td {{.Standard}}
             td {{.ControlKey}}
             td
               strong {{.Name}}
@@ -235,3 +239,26 @@ html lang=en
         }
       }
     }
+
+    var tfConfig = { 
+      base_path: 'https://unpkg.com/tablefilter@latest/dist/tablefilter/',
+      alternate_rows: true,
+      rows_counter: {
+        text: 'Controls: '
+      },
+      btn_reset: {
+        text: 'Clear'
+      },
+      col_types: [
+        'string',
+        'string',
+        'string',
+        'string',
+        'string'
+      ],
+      extensions: [{ name: 'sort' }]
+    }
+
+    var tf = new TableFilter('standards-table',tfConfig);
+    tf.init();
+


### PR DESCRIPTION
My site wants to use Comply for a number of different Standards from the same index. So we end up with many Standards Controls in index.html. It is useful to be able to understand which Standard each Control comes from and to be able to sort and filter on values. 

This PR adds that capability by:
- Adding a column for Standard, and
- Adding TableFilter capability through the unpkg NPM CDN (note this is a new dependency, as other JS dependencies come through CDNJS, which does not have the active TableFilter project).

Some risks in this PR include:
- New dependency on an unmanaged/unverified source (similar to existing CDNJS risk),
- Loss of simplicity by having the TableFilter sorting/filtering controls, and
- Less control over user experience due to client-side code. 

<img width="1379" alt="Screen Shot 2019-08-18 at 3 01 41 PM" src="https://user-images.githubusercontent.com/8451574/63229006-765e7580-c1c9-11e9-940c-b52084ed4393.png">
