### PR TITLE
Default controls to unsatisfied

### DIFF
--- a/internal/model/document.go
+++ b/internal/model/document.go
@@ -8,6 +8,7 @@ type Document struct {
 
 	Revisions      []Revision   `yaml:"majorRevisions"`
 	Satisfies      Satisfaction `yaml:"satisfies"`
+	Live           bool         `yaml:"live"`
 	FullPath       string
 	OutputFilename string
 	ModifiedAt     time.Time

--- a/internal/model/procedure.go
+++ b/internal/model/procedure.go
@@ -9,6 +9,7 @@ type Procedure struct {
 
 	Revisions      []Revision   `yaml:"majorRevisions"`
 	Satisfies      Satisfaction `yaml:"satisfies"`
+	Live           bool         `yaml:"live"`
 	FullPath       string
 	OutputFilename string
 	ModifiedAt     time.Time

--- a/internal/model/standard.go
+++ b/internal/model/standard.go
@@ -25,23 +25,29 @@ func ControlsSatisfied(data *Data) map[string][]string {
 	}
 
 	for _, n := range data.Narratives {
-		for _, controlKeys := range n.Satisfies {
-			for _, key := range controlKeys {
-				satisfied[key] = appendSatisfaction(satisfied, key, n.OutputFilename)
+		if n.Live {
+			for _, controlKeys := range n.Satisfies {
+				for _, key := range controlKeys {
+					satisfied[key] = appendSatisfaction(satisfied, key, n.OutputFilename)
+				}
 			}
 		}
 	}
 	for _, n := range data.Policies {
-		for _, controlKeys := range n.Satisfies {
-			for _, key := range controlKeys {
-				satisfied[key] = appendSatisfaction(satisfied, key, n.OutputFilename)
+		if n.Live {
+			for _, controlKeys := range n.Satisfies {
+				for _, key := range controlKeys {
+					satisfied[key] = appendSatisfaction(satisfied, key, n.OutputFilename)
+				}
 			}
 		}
 	}
 	for _, n := range data.Procedures {
-		for _, controlKeys := range n.Satisfies {
-			for _, key := range controlKeys {
-				satisfied[key] = appendSatisfaction(satisfied, key, n.OutputFilename)
+		if n.Live {
+			for _, controlKeys := range n.Satisfies {
+				for _, key := range controlKeys {
+					satisfied[key] = appendSatisfaction(satisfied, key, n.OutputFilename)
+				}
 			}
 		}
 	}

--- a/themes/comply-soc2/README.md
+++ b/themes/comply-soc2/README.md
@@ -26,6 +26,10 @@ The `output/` directory contains all generated assets. Links in the HTML dashboa
 
 Procedure tracking is updated whenever `comply sync` is invoked. Invoke a sync prior to `comply build` to include the most current ticket status.
 
+## Satisfying controls
+
+The standards specified in `standards/` are satisfied based on the documents located in `narratives/`, and `policies/`, and `procedures/`. The default document templates are mapped to standards according to the `satisfies` YAML front matter, however these default controls will not register as "satisfied" until front matter is added to the document indicating the document is live. This ensures you review the default template and customize for your environment. Set `live: true` in the document once the control described within is active in your environment.
+
 # Procedure Scheduler
 
 Any `procedures/` that include a `cron` schedule will automatically created in your configured ticketing system whenever `comply scheduler` is executed. The scheduler will backfill any overdue tickets.

--- a/themes/comply-soc2/narratives/control.md
+++ b/themes/comply-soc2/narratives/control.md
@@ -1,5 +1,6 @@
 name: Control Environment Narrative
 acronym: CEN
+live: false
 satisfies:
   TSC:
     - CC2.1

--- a/themes/comply-soc2/narratives/organizational.md
+++ b/themes/comply-soc2/narratives/organizational.md
@@ -1,5 +1,6 @@
 name: Organizational Narrative
 acronym: ON
+live: false
 satisfies:
   TSC:
     - CC1.2

--- a/themes/comply-soc2/narratives/security.md
+++ b/themes/comply-soc2/narratives/security.md
@@ -1,5 +1,6 @@
 name: Security Architecture Narrative
 acronym: SEN
+live: false
 satisfies:
   TSC:
     - CC6.6

--- a/themes/comply-soc2/policies/access.md
+++ b/themes/comply-soc2/policies/access.md
@@ -1,5 +1,6 @@
 name: Access Onboarding and Termination Policy
 acronym: AOTP
+live: false
 satisfies:
   TSC:
     - CC6.1

--- a/themes/comply-soc2/policies/application.md
+++ b/themes/comply-soc2/policies/application.md
@@ -1,5 +1,6 @@
 name: Application Security Policy
 acronym: ASP
+live: false
 satisfies:
   TSC:
     - CC6.2

--- a/themes/comply-soc2/policies/availability.md
+++ b/themes/comply-soc2/policies/availability.md
@@ -1,5 +1,6 @@
 name: Availability Policy
 acronym: AP
+live: false
 satisfies:
   TSC:
     - A1.1

--- a/themes/comply-soc2/policies/change.md
+++ b/themes/comply-soc2/policies/change.md
@@ -1,5 +1,6 @@
 name: System Change Policy
 acronym: SCP
+live: false
 satisfies:
   TSC:
     - CC8.1

--- a/themes/comply-soc2/policies/classification.md
+++ b/themes/comply-soc2/policies/classification.md
@@ -1,5 +1,6 @@
 name: Data Classification Policy
 acronym: DCP
+live: false
 satisfies:
   TSC:
     - CC9.9

--- a/themes/comply-soc2/policies/conduct.md
+++ b/themes/comply-soc2/policies/conduct.md
@@ -1,5 +1,6 @@
 name: Code of Conduct Policy
 acronym: COCP
+live: false
 satisfies:
   TSC:
     - CC1.1

--- a/themes/comply-soc2/policies/confidentiality.md
+++ b/themes/comply-soc2/policies/confidentiality.md
@@ -1,5 +1,6 @@
 name: Confidentiality Policy
 acronym: CP
+live: false
 satisfies:
   TSC:
     - C1.1

--- a/themes/comply-soc2/policies/continuity.md
+++ b/themes/comply-soc2/policies/continuity.md
@@ -1,5 +1,6 @@
 name: Business Continuity Policy
 acronym: BCP
+live: false
 satisfies:
   TSC:
     - CC9.1

--- a/themes/comply-soc2/policies/cyber.md
+++ b/themes/comply-soc2/policies/cyber.md
@@ -1,5 +1,6 @@
 name: Cyber Risk Assessment Policy
 acronym: CRP
+live: false
 satisfies:
   TSC:
     - CC9.1

--- a/themes/comply-soc2/policies/datacenter.md
+++ b/themes/comply-soc2/policies/datacenter.md
@@ -1,5 +1,6 @@
 name: Datacenter Policy
 acronym: DP
+live: false
 satisfies:
   TSC:
     - CC6.4

--- a/themes/comply-soc2/policies/development.md
+++ b/themes/comply-soc2/policies/development.md
@@ -1,5 +1,6 @@
 name: Software Development Lifecycle Policy
 acronym: SDLCP
+live: false
 satisfies:
   TSC:
     - CC8.1

--- a/themes/comply-soc2/policies/disaster.md
+++ b/themes/comply-soc2/policies/disaster.md
@@ -1,5 +1,6 @@
 name: Disaster Recovery Policy
 acronym: DRP
+live: false
 satisfies:
   TSC:
     - A1.2

--- a/themes/comply-soc2/policies/encryption.md
+++ b/themes/comply-soc2/policies/encryption.md
@@ -1,5 +1,6 @@
 name: Encryption Policy
 acronym: EP
+live: false
 satisfies:
   TSC:
     - CC9.9

--- a/themes/comply-soc2/policies/incident.md
+++ b/themes/comply-soc2/policies/incident.md
@@ -1,5 +1,6 @@
 name: Security Incident Response Policy
 acronym: SIRP
+live: false
 satisfies:
   TSC:
     - CC7.3

--- a/themes/comply-soc2/policies/information.md
+++ b/themes/comply-soc2/policies/information.md
@@ -1,5 +1,6 @@
 name: Information Security Policy
 acronym: ISP
+live: false
 satisfies:
   TSC:
     - CC9.9

--- a/themes/comply-soc2/policies/log.md
+++ b/themes/comply-soc2/policies/log.md
@@ -1,5 +1,6 @@
 name: Log Management Policy
 acronym: LMP
+live: false
 satisfies:
   TSC:
     - CC7.2

--- a/themes/comply-soc2/policies/media.md
+++ b/themes/comply-soc2/policies/media.md
@@ -1,5 +1,6 @@
 name: Removable Media and Cloud Storage Policy
 acronym: MCP
+live: false
 satisfies:
   TSC:
     - CC6.7

--- a/themes/comply-soc2/policies/office.md
+++ b/themes/comply-soc2/policies/office.md
@@ -1,5 +1,6 @@
 name: Office Security Policy
 acronym: OSP
+live: false
 satisfies:
   TSC:
     - CC6.4

--- a/themes/comply-soc2/policies/password.md
+++ b/themes/comply-soc2/policies/password.md
@@ -1,5 +1,6 @@
 name: Password Policy
 acronym: PWP
+live: false
 satisfies:
   TSC:
     - CC9.9

--- a/themes/comply-soc2/policies/policy.md
+++ b/themes/comply-soc2/policies/policy.md
@@ -1,5 +1,6 @@
 name: Policy Training Policy
 acronym: PTP
+live: false
 satisfies:
   TSC:
     - CC9.9

--- a/themes/comply-soc2/policies/privacy.md
+++ b/themes/comply-soc2/policies/privacy.md
@@ -1,5 +1,6 @@
 name: Privacy Management Policy
 acronym: PMP
+live: false
 satisfies:
   TSC:
     - P1.1

--- a/themes/comply-soc2/policies/processing.md
+++ b/themes/comply-soc2/policies/processing.md
@@ -1,5 +1,6 @@
 name: Processing Integrity Policy
 acronym: PIP
+live: false
 satisfies:
   TSC:
     - PI1.1

--- a/themes/comply-soc2/policies/remote.md
+++ b/themes/comply-soc2/policies/remote.md
@@ -1,5 +1,6 @@
 name: Remote Access Policy
 acronym: REAP
+live: false
 satisfies:
   TSC:
     - CC6.1

--- a/themes/comply-soc2/policies/retention.md
+++ b/themes/comply-soc2/policies/retention.md
@@ -1,5 +1,6 @@
 name: Data Retention Policy
 acronym: RP
+live: false
 satisfies:
   TSC:
     - CC1.2

--- a/themes/comply-soc2/policies/risk.md
+++ b/themes/comply-soc2/policies/risk.md
@@ -1,5 +1,6 @@
 name: Risk Assessment Policy
 acronym: RIAP
+live: false
 satisfies:
   TSC:
     - CC9.1

--- a/themes/comply-soc2/policies/vendor.md
+++ b/themes/comply-soc2/policies/vendor.md
@@ -1,5 +1,6 @@
 name: Vendor Management Policy
 acronym: VMP
+live: false
 satisfies:
   TSC:
     - CC9.2

--- a/themes/comply-soc2/policies/workstation.md
+++ b/themes/comply-soc2/policies/workstation.md
@@ -1,5 +1,6 @@
 name: Workstation Policy
 acronym: WP
+live: false
 satisfies:
   TSC:
     - CC6.8


### PR DESCRIPTION
This would fix https://github.com/strongdm/comply/issues/77

By default the template policies are mapped to TSC 2017 criteria using `satisfies` front matter. Because the logic in comply is to mark controls as satisfied based on this front matter a newly initialized set of templates show all controls as satisfied.

This is confusing to new users as it makes tracking the work to implement the compliance program less obvious and there's no mechanism to manually mark controls/policies as satisfied.

This PR adds a new boolean field to the Document and Procedure structs for `Live` to determine if a document/procedure is live and in-place in an organizations control environment. I've also updated the `ControlsSatisfied()` func to only mark controls as satisfied if the document/procedure has this new field set to true.

To help guide users on the workflow I've also updated the default README to include a section about satisfying controls that describes setting `live: true` once the policy is implemented. To make it even more clear I updated the template files that are already mapped to criteria as having `live: false` added to the front matter to ensure new users have an example of the right front matter.