### PR TITLE
Missing calc and array for md tables to pdf

### DIFF
--- a/themes/comply-blank/templates/default.latex
+++ b/themes/comply-blank/templates/default.latex
@@ -125,7 +125,7 @@ $if(highlighting-macros)$
 $highlighting-macros$
 $endif$
 $if(tables)$
-\usepackage{longtable,booktabs}
+\usepackage{longtable,booktabs,calc,array}
 % Fix footnotes in tables (requires footnote package)
 \IfFileExists{footnote.sty}{\usepackage{footnote}\makesavenoteenv{long table}}{}
 $endif$

--- a/themes/comply-soc2/templates/default.latex
+++ b/themes/comply-soc2/templates/default.latex
@@ -125,7 +125,7 @@ $if(highlighting-macros)$
 $highlighting-macros$
 $endif$
 $if(tables)$
-\usepackage{longtable,booktabs}
+\usepackage{longtable,booktabs,calc,array}
 % Fix footnotes in tables (requires footnote package)
 \IfFileExists{footnote.sty}{\usepackage{footnote}\makesavenoteenv{long table}}{}
 $endif$


### PR DESCRIPTION
When generating pdf some md tables are broken by missing calc and array.