### PR TITLE
Fix hang on pandoc error.

### DIFF
--- a/internal/render/pdf.go
+++ b/internal/render/pdf.go
@@ -10,8 +10,6 @@ import (
 func pdf(output string, live bool, errCh chan error, wg *sync.WaitGroup) {
 	var pdfWG sync.WaitGroup
 
-	errOutputCh := make(chan error)
-
 	for {
 		_, data, err := loadWithStats()
 		if err != nil {
@@ -25,7 +23,7 @@ func pdf(output string, live bool, errCh chan error, wg *sync.WaitGroup) {
 			return
 		}
 		for _, policy := range policies {
-			renderToFilesystem(&pdfWG, errOutputCh, data, policy, live)
+			renderToFilesystem(&pdfWG, errCh, data, policy, live)
 		}
 
 		narratives, err := model.ReadNarratives()
@@ -35,7 +33,7 @@ func pdf(output string, live bool, errCh chan error, wg *sync.WaitGroup) {
 		}
 
 		for _, narrative := range narratives {
-			renderToFilesystem(&pdfWG, errOutputCh, data, narrative, live)
+			renderToFilesystem(&pdfWG, errCh, data, narrative, live)
 		}
 
 		pdfWG.Wait()


### PR DESCRIPTION
This fixes ticket #100.

When pandoc has an error, this code does a blocking send to the error channel:

https://github.com/strongdm/comply/blob/7b75522ee02ba62ecac26f8a758e55e9d22077c6/internal/render/pandoc.go#L21-L24

However, this error channel is never read from:

https://github.com/strongdm/comply/blob/7b75522ee02ba62ecac26f8a758e55e9d22077c6/internal/render/pdf.go#L13

This PR changes things to use the channel passed in from the parent, and with this change comply exits at the first pandoc error instead of hanging. There are definitely other approaches that could be used to fix the hang, but I think this one seems safe and reasonable.

Also related, until #98 is merged anyone setting up a new comply repo is likely to hit pandoc errors (and therefore run into #100).