### PR TITLE
Simplify docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,17 +83,12 @@ COMMANDS:
 Comply is currently only released for Linux and macOS, however from other operating systems it's possible to run using Docker:
 
 ```
-# first pull the latest published docker image
-$ docker pull strongdm/comply
-
 # from an empty directory that will contain your comply project
-$ docker run --rm -v "$PWD":/source -p 4000:4000 -it strongdm/comply
-root@ec4544732298:/source# comply init
+$ docker run --rm -v "$PWD":/source -p 4000:4000 -it strongdm/comply comply init
 ✗ Organization Name:
 
 # serve content live from an established project
-$ docker run --rm -v "$PWD":/source -p 4000:4000 -it strongdm/comply
-root@ae4d499583fc:/source# comply serve
+$ docker run --rm -v "$PWD":/source -p 4000:4000 -it strongdm/comply comply serve
 Serving content of output/ at http://127.0.0.1:4000 (ctrl-c to quit)
 ```
 


### PR DESCRIPTION
You don't need to pull the image ahead of time, and if you combine the commands into one line it's much easier to copy/paste.